### PR TITLE
Add test execution via vstest.console to CI

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -145,12 +145,12 @@ jobs:
     - name: Build
       run: msbuild ${{ env.SolutionPath }} /p:Configuration=${{ env.Configuration }} /p:Platform=x64 /v:m
 
+    - name: Setup VSTest
+      uses: Malcolmnixon/Setup-VSTest@v4
+
     - name: Run tests via vstest.console
-      uses: microsoft/vstest-action@v1.0.0
-      with:
-        testAssembly: '**\*.Test.dll'
-        searchFolder: Tests
-        otherConsoleOptions: '/Framework:.NETFramework,Version=v4.6.1'
+      run: vstest.console "**/bin/**/*Test.dll" /Framework:.NETFramework,Version=v4.6.1
+      working-directory: Tests
 
     # Upload the package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload build artifacts


### PR DESCRIPTION
## Problem

The CI workflow only builds the project but does not run any tests. The tests target net461 and require vstest.console to run on Windows.

Requested by @kant2002 - add test execution via vstest.console to GitHub Actions.

## Solution

Added test execution to `dotnet-desktop.yml` using [Malcolmnixon/Setup-VSTest@v4](https://github.com/Malcolmnixon/Setup-VSTest) to add `vstest.console` to PATH, then running it directly:
- Setup step: `Malcolmnixon/Setup-VSTest@v4`
- Run step: `vstest.console "**/bin/**/*Test.dll" /Framework:.NETFramework,Version=v4.6.1`
- Working directory: `Tests/`

The step runs after the build and before artifact upload.

## Business effect

Every push to master and every PR will be automatically validated with tests, catching regressions before merge.