### PR TITLE
Cross target for .NET 8.0 as minimum

### DIFF
--- a/Confuser.Core/Annotations.cs
+++ b/Confuser.Core/Annotations.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using System.Linq;
 
 namespace Confuser.Core {

--- a/Confuser.Core/Confuser.Core.csproj
+++ b/Confuser.Core/Confuser.Core.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\ConfuserEx.Common.props" Condition="Exists('..\ConfuserEx.Common.props')" />
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Information">

--- a/Confuser.Core/DnlibUtils.cs
+++ b/Confuser.Core/DnlibUtils.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using System.Linq;
 using dnlib.DotNet;
 using dnlib.DotNet.Emit;

--- a/Confuser.Core/UnreachableException.cs
+++ b/Confuser.Core/UnreachableException.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NETFRAMEWORK
+using System;
 
 namespace Confuser.Core {
 	/// <summary>
@@ -12,3 +13,4 @@ namespace Confuser.Core {
 			base("Unreachable code reached.") { }
 	}
 }
+#endif

--- a/Confuser.DynCipher/Confuser.DynCipher.csproj
+++ b/Confuser.DynCipher/Confuser.DynCipher.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\ConfuserEx.Common.props" Condition="Exists('..\ConfuserEx.Common.props')" />
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Information">

--- a/Confuser.MSBuild.Tasks/Confuser.MSBuild.Tasks.csproj
+++ b/Confuser.MSBuild.Tasks/Confuser.MSBuild.Tasks.csproj
@@ -1,10 +1,10 @@
-<!--EXTERNAL_PROPERTIES: TargetFramework;BaseOutputPath-->
+﻿<!--EXTERNAL_PROPERTIES: TargetFramework;BaseOutputPath-->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\ConfuserEx.Common.props" Condition="Exists('..\ConfuserEx.Common.props')" />
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget Package Settings">
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Nuget Dependencies">
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.48" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Project Dependencies">

--- a/Confuser.Protections/AntiDebugProtection.cs
+++ b/Confuser.Protections/AntiDebugProtection.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using System.Linq;
 using Confuser.Core;
 using Confuser.Core.Helpers;

--- a/Confuser.Protections/AntiTamper/AntiTamperProtection.cs
+++ b/Confuser.Protections/AntiTamper/AntiTamperProtection.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NET8_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using System.Linq;
 using Confuser.Core;
 using Confuser.Protections.AntiTamper;

--- a/Confuser.Protections/Confuser.Protections.csproj
+++ b/Confuser.Protections/Confuser.Protections.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\ConfuserEx.Common.props" Condition="Exists('..\ConfuserEx.Common.props')" />
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Information">

--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using System.Linq;
 using Confuser.Core;
 using dnlib.DotNet;

--- a/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
+++ b/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using System.Linq;
 using Confuser.Core;
 using Confuser.Core.Services;

--- a/Confuser.Renamer/Analyzers/LdtokenEnumAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/LdtokenEnumAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NET8_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using Confuser.Core;
 using Confuser.Renamer.References;
 using dnlib.DotNet;

--- a/Confuser.Renamer/Confuser.Renamer.csproj
+++ b/Confuser.Renamer/Confuser.Renamer.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\ConfuserEx.Common.props" Condition="Exists('..\ConfuserEx.Common.props')" />
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Information">

--- a/Confuser.Runtime/Confuser.Runtime.csproj
+++ b/Confuser.Runtime/Confuser.Runtime.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\ConfuserEx.Common.props" Condition="Exists('..\ConfuserEx.Common.props')" />
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Confuser2.slnx
+++ b/Confuser2.slnx
@@ -7,6 +7,8 @@
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
     <File Path="appveyor.yml" />
+    <File Path="ConfuserEx.Common.props" />
+    <File Path="ConfuserEx.Common.targets" />
     <File Path="LICENSE.md" />
     <File Path="README.md" />
     <File Path="version.json" />
@@ -22,7 +24,7 @@
     <Project Path="Tests/193_ConstantsInlining.Test/193_ConstantsInlining.Test.csproj" />
     <Project Path="Tests/193_ConstantsInlining/193_ConstantsInlining.csproj" />
     <Project Path="Tests/244_ClrProtection.Test/244_ClrProtection.Test.csproj" />
-    <Project Path="Tests/244_ClrProtection/244_ClrProtection.vcxproj">
+    <Project Path="Tests/244_ClrProtection/244_ClrProtection.vcxproj" Id="73f11ee8-f565-479e-8366-bd74ee467ce8">
       <Platform Solution="*|Any CPU" Project="Win32" />
     </Project>
     <Project Path="Tests/252_ComplexInterfaceRenaming.Test/252_ComplexInterfaceRenaming.Test.csproj" />

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="*" PrivateAssets="all"
 					  Condition="'$(EnableCodeAnalysis)' != 'false'" />


### PR DESCRIPTION
I think that's reasonable way to start testing on new platforms, and eventually reach cross-platform support.

This change does not include testing support for .NET 8.0