### PR TITLE
Update dnlib to 4.5.0

### DIFF
--- a/Confuser.Core/Confuser.Core.csproj
+++ b/Confuser.Core/Confuser.Core.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Nuget Dependencies">
-    <PackageReference Include="dnlib" Version="3.6.0" />
+    <PackageReference Include="dnlib" Version="4.5.0" />
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.7.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />

--- a/Confuser.Protections/AntiTamper/JITBody.cs
+++ b/Confuser.Protections/AntiTamper/JITBody.cs
@@ -52,6 +52,9 @@ namespace Confuser.Protections.AntiTamper {
 			writer.WriteBytes(Body);
 		}
 
+		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
 		public void Serialize(uint token, uint key, byte[] fieldLayout) {
 			using (var ms = new MemoryStream()) {
 				var writer = new DataWriter(ms);
@@ -234,6 +237,9 @@ namespace Confuser.Protections.AntiTamper {
 				writer.WriteUInt32((length + entry.Value.Offset) >> 2);
 			}
 		}
+
+		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
 
 		public void Add(uint token, JITMethodBody body) {
 			Debug.Assert(bodies.ContainsKey(token));


### PR DESCRIPTION
I introduce fake alignment, since we don't care about it, and it's actually used only to checking for max alignment from what I see in dnlib